### PR TITLE
chore: use https instead of git protocol in roskspec

### DIFF
--- a/lua-resty-rsa-1.1.0-2.rockspec
+++ b/lua-resty-rsa-1.1.0-2.rockspec
@@ -1,7 +1,7 @@
 package = 'lua-resty-rsa'
-version = '1.1.0-1'
+version = '1.1.0-2'
 source = {
-  url = 'git://github.com/spacewander/lua-resty-rsa.git',
+  url = 'https://github.com/spacewander/lua-resty-rsa.git',
   tag = 'v1.1.0'
 }
 description = {


### PR DESCRIPTION
Github turns off unauthenticated port access, this commit replace the git://
protocol with https:// protocol to allow user install module from luarocks.